### PR TITLE
feat: Resizable CLI Events

### DIFF
--- a/cli_automation/cli_api.cpp
+++ b/cli_automation/cli_api.cpp
@@ -11,58 +11,64 @@ using namespace std;
 static EventListener*			g_listeners = NULL;
 static HANDLE					g_hListenerThread = NULL;
 
-static DWORD WINAPI CliListenerThreadProc(LPVOID lpParam) {
-	ExitConfig* exitCfg = (ExitConfig*)lpParam;
-	while (!exitCfg->stop) {
-		if (_kbhit()) {
-			int c = _getch();
-			char ch = (char)tolower(c);
-			BOOL isExitKey = FALSE;
-			for (size_t i = 0; i < exitCfg->size; ++i) {
-				if (c == exitCfg->exitKeys[i] || ch == exitCfg->exitKeys[i]) {
-					isExitKey = TRUE;
-					break;
-				}
-			}
-			if (isExitKey) {
-				CliInputEvent ev = {
-					.base = {
-						.base = {
-							.type = EVENT_EXIT
-						},
-					},
+static DWORD WINAPI CliListenerThreadProc(LPVOID lpParam) {  
+   CLIMenu* menu = (CLIMenu*)lpParam;  
+   HANDLE hConsole = CliGetHandle(STD_INPUT_HANDLE);  
+   SetConsoleMode(hConsole, ENABLE_WINDOW_INPUT | ENABLE_PROCESSED_INPUT);  
+   INPUT_RECORD inputRecord = {}; 
+   DWORD numEvents = 0;
+   while (!menu->exitConfig.stop)
+   {
+	   WaitForSingleObject(hConsole, INFINITE);
+	   ReadConsoleInput(hConsole, &inputRecord, 1, &numEvents);
+	   if (inputRecord.EventType == KEY_EVENT)
+	   {
+		   KEY_EVENT_RECORD keyEvent = inputRecord.Event.KeyEvent;
+		   if (keyEvent.bKeyDown) {
+			   char ch = (char)tolower(keyEvent.uChar.AsciiChar);
+			   int c = keyEvent.wVirtualKeyCode;
+			   CliInputEvent ev = {
+					.base = {.base = {.type = EVENT_INPUT }, },
 					.key = ch
-				};
-				for (EventListener* e = g_listeners; e; e = e->next) {
-					e->callback((const Event*)&ev, e->userData);
-				}
-				exitCfg->stop = TRUE;
-				break;
-			}
-			else {
-				CliInputEvent ev = {
-					.base = {
-						.base = {
-							.type = EVENT_INPUT
-						},
-					},
-					.key = ch
-				};
-				for (EventListener* e = g_listeners; e; e = e->next) {
-					e->callback((const Event*)&ev, e->userData);
-				}
-			}
-		}
-		Sleep(10);
-	}
-	return 0;
+			   };
+			   for (EventListener* e = g_listeners; e; e = e->next) {
+				   e->callback((const Event*)&ev, e->userData);
+			   }
+			   // Is Exit?
+			   for (size_t i = 0; i < menu->exitConfig.size; ++i) {
+				   if (c == menu->exitConfig.exitKeys[i] || ch == menu->exitConfig.exitKeys[i]) {
+					   ev.base.base.type = EVENT_EXIT;
+					   for (EventListener* e = g_listeners; e; e = e->next) {
+						   e->callback((const Event*)&ev, e->userData);
+					   }
+					   ((ExitConfig*)&menu->exitConfig)->stop = TRUE;
+					   exit(EXIT_SUCCESS);
+					   break;
+				   }
+			   }
+		   }
+	   }
+	   if (inputRecord.EventType == WINDOW_BUFFER_SIZE_EVENT)
+	   {
+		   menu->volume = CliGetVolume();
+		   CliEvent resizeEv = {
+				.base = {.type = EVENT_RESIZE },
+				.volume = menu->volume
+		   };
+		   for (EventListener* e = g_listeners; e; e = e->next) {
+			   e->callback((const Event*)&resizeEv, e->userData);
+		   }
+	   }
+   }
+
+   return 0;  
 }
 BOOL CliStartListener(const CLIMenu* menu) {
 	if (!menu || g_hListenerThread != NULL) return FALSE;
 	g_hListenerThread = CreateThread(
 		NULL, 0,
 		CliListenerThreadProc,
-		(LPVOID)&menu->exitConfig, 
+		(LPVOID)menu, 
 		0, NULL
 	);
 	return g_hListenerThread != NULL;
@@ -109,13 +115,17 @@ ScreenVolume CliGetVolume()
 	return vol;
 }
 //	
+void CliPrintMenu(CLIMenu* menu)
+{
+	// Todo: implement print menu
+}
 void CliRunMenu(CLIMenu& menu)
 {
 	if (!CliStartListener(&menu)) {
 		printlnerr("No se pudo iniciar ningun evento");
 		exit(EXIT_FAILURE);
 	}
-	println("Presiona una tecla...");
+	CliPrintMenu(&menu);
 	while (!menu.exitConfig.stop) {
 		Sleep(100);
 	}

--- a/cli_automation/cli_api.h
+++ b/cli_automation/cli_api.h
@@ -41,7 +41,7 @@ typedef struct	EventListener {
 #pragma region  CLIdefinitions
 typedef struct	Option {
 	char key;
-	char* desc;
+	const char* desc;
 } Option;
 typedef struct ExitConfig {
 	const char* desc = "Salir del programa";
@@ -50,7 +50,7 @@ typedef struct ExitConfig {
 	BOOL		stop;
 } ExitConfig;
 typedef struct	Menu {
-	char* title;
+	const char* title;
 	std::vector<Option> opts;
 } Menu;
 typedef struct	CLIMenu : Menu {
@@ -61,6 +61,7 @@ typedef struct	CLIMenu : Menu {
 		.size = sizeof(int[4]) / sizeof(int),
 		.stop = FALSE
 	};
+	EventListener* listeners = NULL;
 } CLIMenu;
 #pragma endregion
 
@@ -73,7 +74,7 @@ void			CliStopListener(void);
 #pragma region  CLI Screen
 void			CliClearRegion(const Coordinates& coords, const ScreenVolume& volume);
 void			CliGotoXY(const Coordinates& coords);
-void			CliPrintMenu(const CLIMenu& menu);
+void			CliPrintMenu(const CLIMenu* menu);
 #pragma endregion
 #pragma region  CLI Helpers
 ScreenVolume	CliGetVolume();

--- a/cli_automation/cli_automation.cpp
+++ b/cli_automation/cli_automation.cpp
@@ -13,22 +13,33 @@ static void onInput(const Event* ev, void* ud) {
 static void onExit(const Event* ev, void* ud) {
 	if (ev->type != EVENT_EXIT) return;
 	println("¡Ok!. Limpiando y cerrando...");
-	exit(EXIT_SUCCESS);
+}
+/* Callback para evento de cambio de resolucion*/
+static void onResize(const Event* ev, void *ud) {
+	if (ev->type == EVENT_RESIZE) {
+		const CliEvent* resizeEv = (const CliEvent*)ev;
+		println("Nuevo tamaño: %dx%d\n", resizeEv->volume.w, resizeEv->volume.h);
+	}
 }
 
 //	Main
 int main()
 {
 	init_utf16_std();
-	Coordinates coords{};
-	ScreenVolume volume = CliGetVolume();
 	CLIMenu mainMenu;
-	coords.x = 5;
-	coords.y = 2;
-	mainMenu.coords = coords;
-	mainMenu.volume = volume;
+	mainMenu.title = "Seleccione una opción";
+	mainMenu.opts = {
+		{ 1, "Opción 1" },
+		{ 2, "Opción 2" },
+		{ 3, "Opción 3" }
+	};
+	mainMenu.coords = {
+		.x = 5,
+		.y = 2
+	};
 	CliAddEventListener(onInput, &mainMenu);
 	CliAddEventListener(onExit, &mainMenu);
+	CliAddEventListener(onResize, NULL);
 	CliRunMenu(mainMenu);
 	return EXIT_SUCCESS;
 }


### PR DESCRIPTION
Mejorar manejo de entrada y estructura del menú CLI

Se ha actualizado la función `CliListenerThreadProc` para utilizar `ReadConsoleInput()`, mejorando la gestión de eventos de teclado y redimensionamiento de ventana. Se ha añadido la función `CliPrintMenu`, que está pendiente de implementación.

El tipo de `desc` en la estructura `Option` se ha cambiado a `const char*` para mayor seguridad. Además, se ha incorporado un puntero a `EventListener` en `CLIMenu` para gestionar múltiples oyentes de eventos.

La firma de `CliPrintMenu` se ha modificado para aceptar un puntero a `CLIMenu`, facilitando la manipulación de memoria. Se han añadido callbacks para manejar eventos de redimensionamiento de ventana y se han realizado ajustes en la función `main` para mejorar la inicialización del menú principal.